### PR TITLE
Exception Thrown when (possibly valid) client_id evaluates to false

### DIFF
--- a/lib/IOAuth2GrantCode.php
+++ b/lib/IOAuth2GrantCode.php
@@ -31,6 +31,7 @@ interface IOAuth2GrantCode extends IOAuth2Storage {
 	 * @return
 	 * An associative array as below, and NULL if the code is invalid:
 	 * - client_id: Stored client identifier.
+     * - user_id: Stored user identifier.
 	 * - redirect_uri: Stored redirect URI.
 	 * - expires: Stored expiration in unix timestamp.
 	 * - scope: (optional) Stored scope values in space-separated string.

--- a/lib/OAuth2.php
+++ b/lib/OAuth2.php
@@ -814,7 +814,7 @@ class OAuth2 {
 		$input = filter_var_array($inputData, $filters);
 		
 		// Make sure a valid client id was supplied (we can not redirect because we were unable to verify the URI)
-		if (!$input["client_id"]) {
+		if (!isset($input["client_id"])) {
 			throw new OAuth2ServerException(self::HTTP_BAD_REQUEST, self::ERROR_INVALID_CLIENT, "No client id supplied"); // We don't have a good URI to use
 		}
 		


### PR DESCRIPTION
`OAuth2::getAuthorizeParams` throws an exception, if the GET client_id parameter evaluates to false in PHP. Replaced
`if (!$input["client_id"])`
with
`if (!isset($input["client_id"]))`.
